### PR TITLE
Pystac item issue

### DIFF
--- a/notebooks/templates/classification.yml
+++ b/notebooks/templates/classification.yml
@@ -19,4 +19,5 @@ dependencies:
   - seaborn
   - stackstac
   - xarray
+  - pystac == 1.11.0
   - pystac-client


### PR DESCRIPTION
Pystac > 1.11.0 raises Value Errors when loading with odc-stac as there are missing parameters (eo:proj or eo:epsg) in the assets.