### PR TITLE
60 add prerequisites section

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,12 +9,12 @@ repos:
       - id: end-of-file-fixer
       - id: check-docstring-first
       - id: check-json
-      - id: double-quote-string-fixer
 
   - repo: https://github.com/psf/black
     rev: 23.12.1
     hooks:
       - id: black
+        args: ["--line-length=88"]
 
   - repo: https://github.com/keewis/blackdoc
     rev: v0.3.9
@@ -25,6 +25,7 @@ repos:
     rev: 7.0.0
     hooks:
       - id: flake8
+        args: ["--max-line-length=88"]
 
   - repo: https://github.com/asottile/seed-isort-config
     rev: v2.2.0
@@ -35,6 +36,7 @@ repos:
     rev: 5.13.2
     hooks:
       - id: isort
+        args: ["--profile=black"]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0
@@ -57,6 +59,7 @@ repos:
     rev: "v0.5.3"
     hooks:
       - id: flake8-nb
+        args: ["--max-line-length=88"]
 
   # - repo: local
   #   hooks:

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,8 @@ preview: $(CONDA_ENV)/envs/eo-datascience $(CONDA_ENV_DIR) $(KERNEL_DIR)
 clean:
 	rm --force --recursive .ipynb_checkpoints/ **/.ipynb_checkpoints/ _book/ \
 		_freeze/ .quarto/ _preview/ ./pytest_cache ./**/**/**/.jupyter_cache \
-		./**/**/.jupyter_cache
+		./**/**/.jupyter_cache *.quarto_ipynb **/*.quarto_ipynb \
+		**/**/*.quarto_ipynb **/__pycache__ **/**/__pycache__ __pycache__
 
 teardown:
 	conda remove -n $(PREFIX)/eo-datascience --all -y

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -54,4 +54,4 @@ execute:
   freeze: auto
   cache: true
   keep-ipynb: true
-  eval: false
+  eval: true

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -31,10 +31,10 @@ book:
         - chapters/courses/microwave-remote-sensing/08_in_class_exercise.qmd
         - chapters/courses/microwave-remote-sensing/09_in_class_exercise.qmd
   appendices:
-    - part: "Templates"
+    - part: chapters/templates/prereqs-templates.qmd
       chapters:
         - chapters/templates/classification.qmd
-    - part: "Tutorials"
+    - part: chapters/tutorials/prereqs-tutorials.qmd
       chapters:
         - chapters/tutorials/floodmapping.qmd
     - chapters/references.qmd
@@ -54,3 +54,4 @@ execute:
   freeze: auto
   cache: true
   keep-ipynb: true
+  eval: false

--- a/chapters/courses/microwave-remote-sensing.qmd
+++ b/chapters/courses/microwave-remote-sensing.qmd
@@ -1,10 +1,6 @@
 ---
 title: Microwave Remote Sensing
-jupyter:
-  kernelspec:
-    name: "microwave-remote-sensing"
-    language: "python"
-    display_name: "microwave-remote-sensing"
+jupyter: python3
 ---
 
 This course at the TU Wien teaches students to read, visualize and analyze Synthetic Aperture Radar (SAR) data. This will aid interpretation of SAR data based upon a physical understanding of sensing principles and the interaction of microwaves with natural objects.

--- a/chapters/courses/microwave-remote-sensing.qmd
+++ b/chapters/courses/microwave-remote-sensing.qmd
@@ -9,6 +9,17 @@ jupyter:
 
 This course at the TU Wien teaches students to read, visualize and analyze Synthetic Aperture Radar (SAR) data. This will aid interpretation of SAR data based upon a physical understanding of sensing principles and the interaction of microwaves with natural objects.
 
+| Concepts | Importance | Notes |
+|---|---|---|
+| [Intro to xarray](https://foundations.projectpythia.org/core/xarray/xarray-intro.html) | Neccesary | |
+| [Dask Arrays](https://foundations.projectpythia.org/core/xarray/dask-arrays-xarray.html)| Neccesary| |
+| [Intake](https://projectpythia.org/intake-cookbook/README.html)|Helpful| |
+| [Matplotlib](https://foundations.projectpythia.org/core/matplotlib.html)|Helpful|Ploting in Python|
+| [Documentation hvPlot](https://hvplot.holoviz.org/)|Helpful|Interactive ploting|
+| [Documentation odc-stac](https://odc-stac.readthedocs.io/en/latest/)|Helpful|Data access|
+
+- **Time to learn**: 30 min
+
 ::: {.callout-note}
 These notebooks contain interactive elements. The full interactive elements can only be viewed on Binder by clicking on the Binder badge or 🚀 button.
 :::

--- a/chapters/templates/prereqs-templates.qmd
+++ b/chapters/templates/prereqs-templates.qmd
@@ -1,10 +1,6 @@
 ---
 title: Templates
-jupyter:
-  kernelspec:
-    name: "microwave-remote-sensing"
-    language: "python"
-    display_name: "eo-datascience"
+jupyter: python3
 ---
 
 This section of the Cookbook covers a wide range of topics. The intent is to

--- a/chapters/templates/prereqs-templates.qmd
+++ b/chapters/templates/prereqs-templates.qmd
@@ -1,0 +1,18 @@
+---
+title: Templates
+jupyter:
+  kernelspec:
+    name: "classification"
+    language: "python"
+    display_name: "classification"
+---
+
+This section of the Cookbook covers a wide range of topics. The intent is to
+showcase different applications of remote sensing, which are not in the context
+of a specific course.
+
+| Concepts | Importance | Notes |
+|---|---|---|
+| [Intro to xarray](https://foundations.projectpythia.org/core/xarray/xarray-intro.html) | Neccesary | |
+
+- **Time to learn**: 30 min

--- a/chapters/templates/prereqs-templates.qmd
+++ b/chapters/templates/prereqs-templates.qmd
@@ -2,9 +2,9 @@
 title: Templates
 jupyter:
   kernelspec:
-    name: "classification"
+    name: "microwave-remote-sensing"
     language: "python"
-    display_name: "classification"
+    display_name: "eo-datascience"
 ---
 
 This section of the Cookbook covers a wide range of topics. The intent is to
@@ -14,5 +14,9 @@ of a specific course.
 | Concepts | Importance | Notes |
 |---|---|---|
 | [Intro to xarray](https://foundations.projectpythia.org/core/xarray/xarray-intro.html) | Neccesary | |
+| [Dask Arrays](https://foundations.projectpythia.org/core/xarray/dask-arrays-xarray.html)| Neccesary| |
+| [Documentation scikit-learn](https://scikit-learn.org/stable/)|Neccesary|Machine Learning in Python|
+| [Documentation Matplotlib](https://matplotlib.org/stable/users/explain/quick_start.html)|Helpful|Ploting in Python|
+| [Documentation odc-stac](https://odc-stac.readthedocs.io/en/latest/)|Helpful|Data access|
 
 - **Time to learn**: 30 min

--- a/chapters/tutorials/prereqs-tutorials.qmd
+++ b/chapters/tutorials/prereqs-tutorials.qmd
@@ -1,10 +1,6 @@
 ---
 title: Tutorials
-jupyter:
-  kernelspec:
-    name: "microwave-remote-sensing"
-    language: "python"
-    display_name: "eo-datascience"
+jupyter: python3
 ---
 
 This section of the Cookbook covers a wide range of topics. The intent is to

--- a/chapters/tutorials/prereqs-tutorials.qmd
+++ b/chapters/tutorials/prereqs-tutorials.qmd
@@ -1,5 +1,5 @@
 ---
-title: Templates
+title: Tutorials
 jupyter:
   kernelspec:
     name: "microwave-remote-sensing"
@@ -13,6 +13,10 @@ of a specific course.
 
 | Concepts | Importance | Notes |
 |---|---|---|
-| Something| comes | here |
+| [Intro to xarray](https://foundations.projectpythia.org/core/xarray/xarray-intro.html) | Neccesary | |
+| [Dask Arrays](https://foundations.projectpythia.org/core/xarray/dask-arrays-xarray.html)| Neccesary| |
+| [Documentation hvPlot](https://hvplot.holoviz.org/)|Helpful|Interactive ploting|
+| [Documentation odc-stac](https://odc-stac.readthedocs.io/en/latest/)|Helpful|Data access|
+| [Scientific Background](https://www.mdpi.com/2072-4292/14/15/3673)|Helpful||
 
 - **Time to learn**: 30 min

--- a/chapters/tutorials/prereqs-tutorials.qmd
+++ b/chapters/tutorials/prereqs-tutorials.qmd
@@ -1,0 +1,18 @@
+---
+title: Templates
+jupyter:
+  kernelspec:
+    name: "microwave-remote-sensing"
+    language: "python"
+    display_name: "eo-datascience"
+---
+
+This section of the Cookbook covers a wide range of topics. The intent is to
+showcase different applications of remote sensing, which are not in the context
+of a specific course.
+
+| Concepts | Importance | Notes |
+|---|---|---|
+| Something| comes | here |
+
+- **Time to learn**: 30 min

--- a/notebooks/templates/prereqs-templates.ipynb
+++ b/notebooks/templates/prereqs-templates.ipynb
@@ -1,0 +1,43 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "title: Templates\n",
+    "jupyter:\n",
+    "  kernelspec:\n",
+    "    name: \"microwave-remote-sensing\"\n",
+    "    language: \"python\"\n",
+    "    display_name: \"eo-datascience\"\n",
+    "---\n",
+    "\n",
+    "\n",
+    "This section of the Cookbook covers a wide range of topics. The intent is to\n",
+    "showcase different applications of remote sensing, which are not in the context\n",
+    "of a specific course.\n",
+    "\n",
+    "| Concepts | Importance | Notes |\n",
+    "|---|---|---|\n",
+    "| [Intro to xarray](https://foundations.projectpythia.org/core/xarray/xarray-intro.html) | Neccesary | |\n",
+    "| [Dask Arrays](https://foundations.projectpythia.org/core/xarray/dask-arrays-xarray.html)| Neccesary| |\n",
+    "| [Documentation scikit-learn](https://scikit-learn.org/stable/)|Neccesary|Machine Learning in Python|\n",
+    "| [Documentation Matplotlib](https://matplotlib.org/stable/users/explain/quick_start.html)|Helpful|Ploting in Python|\n",
+    "| [Documentation odc-stac](https://odc-stac.readthedocs.io/en/latest/)|Helpful|Data access|\n",
+    "\n",
+    "- **Time to learn**: 30 min"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "eo-datascience",
+   "language": "python",
+   "name": "microwave-remote-sensing"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/tutorials/prereqs-tutorials.ipynb
+++ b/notebooks/tutorials/prereqs-tutorials.ipynb
@@ -1,0 +1,55 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "title: Tutorials\n",
+    "jupyter:\n",
+    "  kernelspec:\n",
+    "    name: \"microwave-remote-sensing\"\n",
+    "    language: \"python\"\n",
+    "    display_name: \"eo-datascience\"\n",
+    "---\n",
+    "\n",
+    "\n",
+    "This section of the Cookbook covers a wide range of topics. The intent is to\n",
+    "showcase different applications of remote sensing, which are not in the context\n",
+    "of a specific course.\n",
+    "\n",
+    "| Concepts | Importance | Notes |\n",
+    "|---|---|---|\n",
+    "| [Intro to xarray](https://foundations.projectpythia.org/core/xarray/xarray-intro.html) | Neccesary | |\n",
+    "| [Dask Arrays](https://foundations.projectpythia.org/core/xarray/dask-arrays-xarray.html)| Neccesary| |\n",
+    "| [Documentation hvPlot](https://hvplot.holoviz.org/)|Helpful|Interactive ploting|\n",
+    "| [Documentation odc-stac](https://odc-stac.readthedocs.io/en/latest/)|Helpful|Data access|\n",
+    "| [Scientific Background](https://www.mdpi.com/2072-4292/14/15/3673)|Helpful||\n",
+    "\n",
+    "- **Time to learn**: 30 min"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "eo-datascience",
+   "language": "python",
+   "name": "microwave-remote-sensing"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/eo_datascience/render_sfinx_toc.py
+++ b/src/eo_datascience/render_sfinx_toc.py
@@ -1,6 +1,8 @@
-from pathlib import Path
-import yaml
 import argparse
+from pathlib import Path
+from typing import Literal
+
+import yaml
 from eo_datascience.clean_nb import substitute_path
 
 
@@ -35,22 +37,44 @@ def transform_appendix(toc):
     return rename_keys_section(extract_appendix(toc), "appendix")
 
 
-def rename_keys_section(sections, part="main"):
+def rename_keys_section(
+    sec,
+    part: Literal["main", "appendix"],
+):
+    sections = sec.copy()
     for i, section in enumerate(sections):
         sections[i] = _rename_keys_section(section, ("part", "caption"))
         if part == "main":
-            restruct = [
-                {
-                    "file": sections[i]["caption"][i]["file"],
-                    "sections": sections[i]["chapters"],
-                }
-            ]
-            sections[i]["chapters"] = restruct
-            sections[i]["caption"] = "Courses"
+            restructure_section_main(sections, i)
+        elif part == "appendix":
+            restructure_section_appendix(sections, i)
         else:
             sections[i]["caption"] = sections[i]["caption"][0]["file"]
 
     return sections
+
+
+def restructure_section_main(sections, i):
+    restruct = [
+        {
+            "file": sections[i]["caption"][i]["file"],
+            "sections": sections[i]["chapters"],
+        }
+    ]
+    sections[i]["chapters"] = restruct
+    sections[i]["caption"] = "Courses"
+
+
+def restructure_section_appendix(sections, i):
+    restruct = [
+        {
+            "file": sections[i]["caption"][0]["file"],
+            "sections": sections[i]["chapters"],
+        }
+    ]
+    name = sections[i]["caption"][0]["file"].split("/")[1]
+    sections[i]["chapters"] = restruct
+    sections[i]["caption"] = name.capitalize()
 
 
 def _rename_keys_section(section, key_rename):

--- a/tests/test_quarto_nb_conversions.py
+++ b/tests/test_quarto_nb_conversions.py
@@ -1,25 +1,26 @@
-import nbformat
 from pathlib import Path
-import pytest
+
+import nbformat  # noqa
+import pytest  # noqa
 import yaml
-from eo_datascience.render_sfinx_toc import (
-    _render_toc,
-    transform_main,
-    transform_appendix,
-    extract_main,
-    extract_appendix,
-    rename_keys_section,
-    rename_file_path,
-)
 from eo_datascience.clean_nb import (
     clean_up_frontmatter,
+    convert_callout_notes,
     convert_refs,
+    find_ipynb,
+    quarto_note_replace,
     quarto_ref_person_replace,
     quarto_ref_time_replace,
-    convert_callout_notes,
-    quarto_note_replace,
-    find_ipynb,
     substitute_path,
+)
+from eo_datascience.render_sfinx_toc import (
+    _render_toc,
+    extract_appendix,
+    extract_main,
+    rename_file_path,
+    rename_keys_section,
+    transform_appendix,
+    transform_main,
 )
 
 
@@ -28,13 +29,15 @@ def test_toc_conversion():
     project:
       type: book
       pre-render:
-          - make kernel
-      post-render: make post-render
+        - make kernel
+      post-render:
+        - quarto convert chapters/references.qmd
+        - make post-render
 
     book:
       title: "Earth Observation Datascience"
       author: ""
-      date: "7/10/2024"
+      date: "10 January 2025"
       chapters:
         - index.qmd
         - part: chapters/courses/microwave-remote-sensing.qmd
@@ -42,10 +45,10 @@ def test_toc_conversion():
             - chapters/courses/microwave-remote-sensing/01_in_class_exercise.qmd
             - chapters/courses/microwave-remote-sensing/02_in_class_exercise.qmd
       appendices:
-        - part: "Templates"
+        - part: chapters/templates/prereqs-templates.qmd
           chapters:
             - chapters/templates/classification.qmd
-        - part: "Tutorials"
+        - part: chapters/tutorials/prereqs-tutorials.qmd
           chapters:
             - chapters/tutorials/floodmapping.qmd
         - chapters/references.qmd
@@ -66,10 +69,14 @@ def test_toc_conversion():
           - file: notebooks/courses/microwave-remote-sensing/02_in_class_exercise
     - caption: Templates
       chapters:
-        - file: notebooks/templates/classification
+      - file: notebooks/templates/prereqs-templates
+        sections:
+          - file: notebooks/templates/classification
     - caption: Tutorials
       chapters:
-        - file: notebooks/tutorials/floodmapping
+      - file: notebooks/tutorials/prereqs-tutorials
+        sections:
+          - file: notebooks/tutorials/floodmapping
     - caption: References
       chapters:
         - file: notebooks/references
@@ -104,11 +111,21 @@ def test_toc_conversion():
     assert rename_keys_section(append, "appendix") == [
         {
             "caption": "Templates",
-            "chapters": [{"file": "notebooks/templates/classification"}],
+            "chapters": [
+                {
+                    "file": "notebooks/templates/prereqs-templates",
+                    "sections": [{"file": "notebooks/templates/classification"}],
+                }
+            ],
         },
         {
             "caption": "Tutorials",
-            "chapters": [{"file": "notebooks/tutorials/floodmapping"}],
+            "chapters": [
+                {
+                    "file": "notebooks/tutorials/prereqs-tutorials",
+                    "sections": [{"file": "notebooks/tutorials/floodmapping"}],
+                }
+            ],
         },
     ]
 


### PR DESCRIPTION
The following things have been done:
- Prerequisites Notebooks have been added to Templates and Tutorials
- the pro commit configuration has lost the double-quote string fixer and gained a common max line length for the formatters.
- clean target in makefile now also deletes the caches and the "in-between" quarto_ipynb files
- the rendering of the toc was overhauled to accompany the new structure of the book
- According tests for the rendering have been put in place